### PR TITLE
Add full screen loader and revert required Magento_SalesRule condition

### DIFF
--- a/view/frontend/web/js/action/checkout/cart/totals.js
+++ b/view/frontend/web/js/action/checkout/cart/totals.js
@@ -4,13 +4,16 @@ define([
     'Magento_Checkout/js/model/quote',
     'mage/storage',
     'mage/url',
-    'Magento_Checkout/js/action/get-totals'
-], function (ko, $, quote, storage, urlBuilder, getTotalsAction) {
+    'Magento_Checkout/js/action/get-totals',
+    'Magento_Checkout/js/model/full-screen-loader'
+], function (ko, $, quote, storage, urlBuilder, getTotalsAction, fullScreenLoader) {
         'use strict';
 
         return function (isLoading, payment) {
             let isEnabled = window.checkoutConfig.mageprince_paymentfee.isEnabled;
             if (isEnabled) {
+                fullScreenLoader.startLoader();
+
                 return storage.post(
                     urlBuilder.build('paymentfee/calculate/paymentfee'),
                     JSON.stringify({payment: payment})
@@ -23,6 +26,8 @@ define([
                     }
                 }).fail(function () {
                     isLoading(false);
+                }).always(function () {
+                    fullScreenLoader.stopLoader();
                 });
             }
         };

--- a/view/frontend/web/js/action/payment/select-payment-method-mixin.js
+++ b/view/frontend/web/js/action/payment/select-payment-method-mixin.js
@@ -13,11 +13,9 @@ define(
             return wrapper.wrap(selectPaymentMethodAction, function (originalSelectPaymentMethodAction, paymentMethod) {
                 originalSelectPaymentMethodAction(paymentMethod);
 
-                if (!require.defined('Magento_SalesRule/js/action/select-payment-method-mixin')) {
-                    let isEnabled = window.checkoutConfig.mageprince_paymentfee.isEnabled;
-                    if (isEnabled) {
-                        totals(isLoading, paymentMethod['method']);
-                    }
+                let isEnabled = window.checkoutConfig.mageprince_paymentfee.isEnabled;
+                if (isEnabled) {
+                    totals(isLoading, paymentMethod['method']);
                 }
             });
         };


### PR DESCRIPTION
Hi,

In this MR I propose to add a full screen loader to avoid clicking on place order before this request starts / ends because the cart can be closed before paymentfee finished execution.

Also, I am removing / revert "require.defined" because magento can throw an exception to the sales rules, thus causing the total information to be incorrect for the payment method.

On the other hand, what is "isLoading" for ?