### PR TITLE
Update select-payment-method-mixin.js

### DIFF
--- a/view/frontend/web/js/action/payment/select-payment-method-mixin.js
+++ b/view/frontend/web/js/action/payment/select-payment-method-mixin.js
@@ -14,7 +14,7 @@ define(
                 originalSelectPaymentMethodAction(paymentMethod);
 
                 let isEnabled = window.checkoutConfig.mageprince_paymentfee.isEnabled;
-                if (isEnabled) {
+                if (isEnabled && paymentMethod) {
                     totals(isLoading, paymentMethod['method']);
                 }
             });


### PR DESCRIPTION
As in the original method, before accessing "paymentMethod" it must be checked if it exists.